### PR TITLE
port scan now only returns open ports

### DIFF
--- a/phaser/src/ports/mod.rs
+++ b/phaser/src/ports/mod.rs
@@ -33,11 +33,12 @@ async fn scan_port(hostname: &str, port: u16) -> Option<Port> {
 
     // TODO: detect protocol
     match tokio::time::timeout(timeout, TcpStream::connect(&socket_addresses[0])).await {
-        Ok(_) => Some(Port {
-            port: port,
+        Ok(Ok(_)) => Some(Port {
+            port,
             protocol: Protocol::Tcp,
             findings: Vec::new(),
         }),
+        Ok(Err(_)) => None,
         Err(_) => None,
     }
 }


### PR DESCRIPTION
Hello,

I think I found a little bug in the port scan. `tokio::time::timeout` will return a `Result` on completion. The returning result means if the future completes before the duration `Ok` is returned otherwise `Err`. If a connection to a port will result in a connection refused, than `Ok` is returned from `tokio::time::timeout` and the inner value is `Err` from `TcpStream::connect`. I changed the part so the port scan only returns open ports.

